### PR TITLE
Remove escaping from inout closuers

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4015,6 +4015,9 @@ ERROR(autoclosure_function_input_nonunit,none,
 ERROR(escaping_non_function_parameter,none,
       "@escaping attribute may only be used in function parameter position", ())
 
+ERROR(escaping_inout_parameter,none,
+      "inout expression is implicitly escaping by definition", ())
+
 ERROR(escaping_optional_type_argument, none,
       "closure is already escaping in optional type argument", ())
 

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -3393,6 +3393,10 @@ TypeResolver::resolveAttributedType(TypeRepr *repr, TypeResolutionOptions option
           diagnoseInvalid(repr, repr->getLoc(),
                           diag::escaping_optional_type_argument)
               .fixItRemove(attrRange);
+        } else if (options.is(TypeResolverContext::InoutFunctionInput)) {
+          diagnoseInvalid(repr, repr->getLoc(),
+                          diag::escaping_inout_parameter)
+              .fixItRemove(attrRange);
         } else {
           diagnoseInvalid(repr, loc, diag::escaping_non_function_parameter)
               .fixItRemove(attrRange);

--- a/test/Sema/escaping_inout_arugment.swift
+++ b/test/Sema/escaping_inout_arugment.swift
@@ -1,0 +1,6 @@
+// RUN: %target-typecheck-verify-swift
+
+func testInoutEscaping() {
+    let _: (_ v: inout @escaping () -> Void) -> ()
+    // expected-error@-1 {{inout expression is implicitly escaping by definition}}
+}

--- a/test/Sema/escaping_inout_arugment.swift
+++ b/test/Sema/escaping_inout_arugment.swift
@@ -1,6 +1,0 @@
-// RUN: %target-typecheck-verify-swift
-
-func testInoutEscaping() {
-    let _: (_ v: inout @escaping () -> Void) -> ()
-    // expected-error@-1 {{inout expression is implicitly escaping by definition}}
-}

--- a/test/attr/escaping_inout_arugment.swift
+++ b/test/attr/escaping_inout_arugment.swift
@@ -1,0 +1,7 @@
+// RUN: %target-typecheck-verify-swift
+
+let _: (_ v: inout @escaping () -> Void) -> ()
+// expected-error@-1 {{inout expression is implicitly escaping by definition}}
+
+func m(v: inout @escaping () -> Void) {}
+// expected-error@-1 {{inout expression is implicitly escaping by definition}}


### PR DESCRIPTION
<!-- What's in this pull request? -->
In This PR (as my first contribution to the project) i add support for better diagnostics message when there's an `inout @escaping` closure

so instead of: 
```swift
func m(v: inout @escaping () -> Void) {}

```

we get

```swift
error: inout expression is implicitly escaping by definition
func m(v: inout @escaping () -> Void) {}
                ~~~~~~~~~~   ^
```
<!--
If this pull request resolves any GitHub issues, link them.
For information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
Resolves #NNNNN, fix apple/llvm-project#MMMMM.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
